### PR TITLE
Change links to Markdown

### DIFF
--- a/rocketchat-host-notification.sh
+++ b/rocketchat-host-notification.sh
@@ -15,5 +15,5 @@ else
 fi
 
 #Send message to Rocket.Chat
-PAYLOAD="payload={\"text\": \"${ICON} ${NOTIFICATIONTYPE} <https://${ICINGA_HOSTNAME}/icingaweb2/monitoring/host/services?host=${HOSTNAME}|${HOSTDISPLAYNAME}>: *${HOSTSTATE}* | ${HOSTOUTPUT} | [ *${NOTIFICATIONAUTHORNAME}* ] ${NOTIFICATIONCOMMENT} \"}"
+PAYLOAD="payload={\"text\": \"${ICON} ${NOTIFICATIONTYPE} [${HOSTDISPLAYNAME}](https://${ICINGA_HOSTNAME}/icingaweb2/monitoring/host/services?host=${HOSTNAME}): *${HOSTSTATE}* | ${HOSTOUTPUT} | [ *${NOTIFICATIONAUTHORNAME}* ] ${NOTIFICATIONCOMMENT} \"}"
 curl --connect-timeout 30 --max-time 60 -s -S -X POST --data-urlencode "${PAYLOAD}" "${ROCKETCHAT_WEBHOOK_URL}"

--- a/rocketchat-service-notification.sh
+++ b/rocketchat-service-notification.sh
@@ -21,5 +21,5 @@ else
 fi
 
 #Send message to Rocket.Chat
-PAYLOAD="payload={\"text\": \"${ICON} ${NOTIFICATIONTYPE} <https://${ICINGA_HOSTNAME}/icingaweb2/monitoring/host/services?host=${HOSTNAME}|${HOSTDISPLAYNAME}> (<https://${ICINGA_HOSTNAME}/icingaweb2/monitoring/service/show?host=${HOSTNAME}&service=${SERVICEDESC}|${SERVICEDISPLAYNAME}>): *${SERVICESTATE}* | ${SERVICEOUTPUT} | [ *${NOTIFICATIONAUTHORNAME}* ] ${NOTIFICATIONCOMMENT} \"}"
+PAYLOAD="payload={\"text\": \"${ICON} ${NOTIFICATIONTYPE} [${HOSTDISPLAYNAME}](https://${ICINGA_HOSTNAME}/icingaweb2/monitoring/host/services?host=${HOSTNAME}) ([${SERVICEDISPLAYNAME}](<https://${ICINGA_HOSTNAME}/icingaweb2/monitoring/service/show?host=${HOSTNAME}&service=${SERVICEDESC})): *${SERVICESTATE}* | ${SERVICEOUTPUT} | [ *${NOTIFICATIONAUTHORNAME}* ] ${NOTIFICATIONCOMMENT} \"}"
 curl --connect-timeout 30 --max-time 60 -s -S -X POST --data-urlencode "${PAYLOAD}" "${ROCKETCHAT_WEBHOOK_URL}"


### PR DESCRIPTION
There was a fix for Rocket Chat 0.70.0 fixing double escaped links in markdown. It got only fixed in markdown, so I changed the script to use markdown.

https://github.com/RocketChat/Rocket.Chat/pull/12140